### PR TITLE
API change proposal

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,207 +1,56 @@
 import { flow } from "mobx-state-tree";
-import { FlowReturn } from "mobx-state-tree/dist/core/flow";
 
-export type NoInputStepFn<TOutput> = () => Promise<TOutput> | TOutput;
+type StripPromise<T> = T extends Promise<infer U> ? U : T;
 
-export type StepFn<TInput, TOutput> = (
-  input: TInput
-) => Promise<TOutput> | TOutput;
-
-export type FlowFn<TInput, TOutput> = (
-  input: TInput
-) => Promise<FlowReturn<TOutput>>;
-
-export type NoInputFlowFn<TOutput> = () => Promise<FlowReturn<TOutput>>;
-
-export type ErrorHandlerFn<E> = (error: any) => E;
-
-export function flowPipe<T0>(step0: NoInputStepFn<T0>): NoInputFlowFn<T0>;
-export function flowPipe<I, T0>(step0: StepFn<I, T0>): FlowFn<I, T0>;
-
-export function flowPipe<T0, T1>(
-  step0: NoInputStepFn<T0>,
-  step1: StepFn<T0, T1>
-): NoInputFlowFn<T1>;
-export function flowPipe<I, T0, T1>(
-  step0: StepFn<I, T0>,
-  step1: StepFn<T0, T1>
-): FlowFn<I, T1>;
-
-export function flowPipe<T0, T1, T2>(
-  step0: NoInputStepFn<T0>,
-  step1: StepFn<T0, T1>,
-  step2: StepFn<T1, T2>
-): NoInputFlowFn<T2>;
-export function flowPipe<I, T0, T1, T2>(
-  step0: StepFn<I, T0>,
-  step1: StepFn<T0, T1>,
-  step2: StepFn<T1, T2>
-): FlowFn<I, T2>;
-
-export function flowPipe<T0, T1, T2, T3>(
-  step0: NoInputStepFn<T0>,
-  step1: StepFn<T0, T1>,
-  step2: StepFn<T1, T2>,
-  step3: StepFn<T2, T3>
-): NoInputFlowFn<T3>;
-export function flowPipe<I, T0, T1, T2, T3>(
-  step0: StepFn<I, T0>,
-  step1: StepFn<T0, T1>,
-  step2: StepFn<T1, T2>,
-  step3: StepFn<T2, T3>
-): FlowFn<I, T3>;
-
-export function flowPipe<T0, T1, T2, T3, T4>(
-  step0: NoInputStepFn<T0>,
-  step1: StepFn<T0, T1>,
-  step2: StepFn<T1, T2>,
-  step3: StepFn<T2, T3>,
-  step4: StepFn<T3, T4>
-): NoInputFlowFn<T3>;
-export function flowPipe<I, T0, T1, T2, T3, T4>(
-  step0: StepFn<I, T0>,
-  step1: StepFn<T0, T1>,
-  step2: StepFn<T1, T2>,
-  step3: StepFn<T2, T3>,
-  step4: StepFn<T3, T4>
-): FlowFn<I, T3>;
-
-export function flowPipe<T0, T1, T2, T3, T4, T5>(
-  step0: NoInputStepFn<T0>,
-  step1: StepFn<T0, T1>,
-  step2: StepFn<T1, T2>,
-  step3: StepFn<T2, T3>,
-  step4: StepFn<T3, T4>,
-  step5: StepFn<T4, T5>
-): NoInputFlowFn<T3>;
-export function flowPipe<I, T0, T1, T2, T3, T4, T5>(
-  step0: StepFn<I, T0>,
-  step1: StepFn<T0, T1>,
-  step2: StepFn<T1, T2>,
-  step3: StepFn<T2, T3>,
-  step4: StepFn<T3, T4>,
-  step5: StepFn<T4, T5>
-): FlowFn<I, T3>;
-
-export function flowPipe<T0, E>(
-  steps: [NoInputStepFn<T0>],
-  errorHandler?: ErrorHandlerFn<E>
-): NoInputFlowFn<T0 | E>;
-export function flowPipe<I, T0, E>(
-  steps: [StepFn<I, T0>],
-  errorHandler?: ErrorHandlerFn<E>
-): FlowFn<I, T0 | E>;
-
-export function flowPipe<T0, T1, E>(
-  steps: [NoInputStepFn<T0>, StepFn<T0, T1>],
-  errorHandler?: ErrorHandlerFn<E>
-): NoInputFlowFn<T1 | E>;
-export function flowPipe<I, T0, T1, E>(
-  steps: [StepFn<I, T0>, StepFn<T0, T1>],
-  errorHandler?: ErrorHandlerFn<E>
-): FlowFn<I, T1 | E>;
-
-export function flowPipe<T0, T1, T2, E>(
-  steps: [NoInputStepFn<T0>, StepFn<T0, T1>, StepFn<T1, T2>],
-  errorHandler?: ErrorHandlerFn<E>
-): NoInputFlowFn<T2 | E>;
-export function flowPipe<I, T0, T1, T2, E>(
-  steps: [StepFn<I, T0>, StepFn<T0, T1>, StepFn<T1, T2>],
-  errorHandler?: ErrorHandlerFn<E>
-): FlowFn<I, T2 | E>;
-
-export function flowPipe<T0, T1, T2, T3, E>(
-  steps: [NoInputStepFn<T0>, StepFn<T0, T1>, StepFn<T1, T2>, StepFn<T2, T3>],
-  errorHandler?: ErrorHandlerFn<E>
-): NoInputFlowFn<T3 | E>;
-export function flowPipe<I, T0, T1, T2, T3, E>(
-  steps: [StepFn<I, T0>, StepFn<T0, T1>, StepFn<T1, T2>, StepFn<T2, T3>],
-  errorHandler?: ErrorHandlerFn<E>
-): FlowFn<I, T3 | E>;
-
-export function flowPipe<T0, T1, T2, T3, T4, E>(
-  steps: [
-    NoInputStepFn<T0>,
-    StepFn<T0, T1>,
-    StepFn<T1, T2>,
-    StepFn<T2, T3>,
-    StepFn<T3, T4>
-  ],
-  errorHandler?: ErrorHandlerFn<E>
-): NoInputFlowFn<T4 | E>;
-export function flowPipe<I, T0, T1, T2, T3, T4, E>(
-  steps: [
-    StepFn<I, T0>,
-    StepFn<T0, T1>,
-    StepFn<T1, T2>,
-    StepFn<T2, T3>,
-    StepFn<T3, T4>
-  ],
-  errorHandler?: ErrorHandlerFn<E>
-): FlowFn<I, T4 | E>;
-
-export function flowPipe<T0, T1, T2, T3, T4, T5, E>(
-  steps: [
-    NoInputStepFn<T0>,
-    StepFn<T0, T1>,
-    StepFn<T1, T2>,
-    StepFn<T2, T3>,
-    StepFn<T3, T4>,
-    StepFn<T3, T5>
-  ],
-  errorHandler?: ErrorHandlerFn<E>
-): NoInputFlowFn<T5 | E>;
-export function flowPipe<I, T0, T1, T2, T3, T4, T5, E>(
-  steps: [
-    StepFn<I, T0>,
-    StepFn<T0, T1>,
-    StepFn<T1, T2>,
-    StepFn<T2, T3>,
-    StepFn<T3, T4>,
-    StepFn<T4, T5>
-  ],
-  errorHandler?: ErrorHandlerFn<E>
-): FlowFn<I, T5 | E>;
-
-export function flowPipe(...args: any[]) {
-  if (args.length == 0) throw new Error(`must be one or more args`);
-
-  if (typeof args[0] == "function") {
-    return flowWithNoErrors(args);
-  } else if (Array.isArray(args[0]) && !args[1]) {
-    return flowWithNoErrors(args[0]);
-  } else if (Array.isArray(args[0]) && typeof args[1] == "function") {
-    return flowAndCatchErrors(args[0], args[1]);
-  } else {
-    throw new Error(`invalid argument at 0`);
-  }
+interface FlowContinuation<TArgs extends unknown[], TRes> {
+  then<TResNext>(nextFn: (input: TRes) => TResNext): FlowContinuation<TArgs, StripPromise<TResNext>>;
+  catch<TResNext>(nextFn: (input: any) => TResNext): FlowContinuation<TArgs, StripPromise<TResNext> | TRes>;
+  end(): (...args: TArgs) => Promise<TRes>
 }
 
-const flowWithNoErrors = (steps: StepFn<any, any>[]) => {
-  return flow(function* (input: any) {
-    for (let step of steps) {
-      const result = step(input);
-      input = yield isPromise(result) ? result : Promise.resolve(result);
-    }
-    return input;
-  });
-};
+interface UntypedStepFn {
+  type: "init" | "then" | "catch",
+  handle: (...inputs: unknown[]) => unknown
+}
 
-const flowAndCatchErrors = (
-  steps: StepFn<any, any>[],
-  errorHandler: ErrorHandlerFn<any>
-) => {
-  return flow(function* (input: any) {
-    try {
-      for (let step of steps) {
-        const result = step(input);
-        input = yield isPromise(result) ? result : Promise.resolve(result);
+const coerceToPromise = <T>(input: T): Promise<T> =>
+  isPromise(input)
+    ? input
+    : Promise.resolve(input);
+
+const continueFlow = <TArgs extends unknown[], TRes>(steps: UntypedStepFn[]): FlowContinuation<TArgs, TRes> => ({
+  then: (nextFn) => continueFlow([...steps, { type: "then", handle: nextFn }]),
+  catch: (nextFn) => continueFlow([...steps, { type: "catch", handle: nextFn }]),
+  end: () => flow(function* (...args: TArgs) {
+    if (steps.length === 0) return undefined as any;
+    let nextArgs: unknown[] = args;
+    let isHandlingError = false;
+    for (const step of steps) {
+      try {
+        if (isHandlingError) {
+          if (step.type !== "catch") continue;
+          nextArgs = [yield coerceToPromise(step.handle(...nextArgs))];
+          isHandlingError = false;
+        } else {
+          if (step.type === "catch") continue;
+          nextArgs = [yield coerceToPromise(step.handle(...nextArgs))];
+        }
+      } catch (e) {
+        isHandlingError = true;
+        nextArgs = [e];
       }
-    } catch (err) {
-      return errorHandler(err);
     }
-    return input;
-  });
-};
+    if (isHandlingError) {
+      throw nextArgs[0];
+    } else return nextArgs[0] as TRes;
+  })
+})
 
-const isPromise = (o: any) => o != undefined && o.hasOwnProperty("then");
+export const flowPipe = <TArgs extends unknown[], TRes>(initFn: (...inputs: TArgs) => TRes): FlowContinuation<TArgs, StripPromise<TRes>> =>
+  continueFlow([{
+    type: "init",
+    handle: initFn
+  }]);
+
+
+const isPromise = <T extends {}>(o: T): o is T & Promise<T> => o != undefined && o.hasOwnProperty("then");

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,16 +1,15 @@
-import { flowPipe, FlowFn } from "../src/index";
+import { flowPipe } from "../src/index";
 import { types, onPatch, IJsonPatch } from "mobx-state-tree";
 
 it("returns the last resolved value from the pipe", async () => {
   const store = types
     .model({})
     .actions((self) => ({
-      action1: flowPipe(() => 123),
-      action2: flowPipe(() => Promise.resolve("456")),
-      action3: flowPipe(
-        () => Promise.resolve("456"),
-        (x) => Promise.resolve(x + "789")
-      ),
+      action1: flowPipe(() => 123).end(),
+      action2: flowPipe(() => Promise.resolve("456")).end(),
+      action3: flowPipe(() => Promise.resolve("456"))
+        .then((x) => Promise.resolve(x + "789"))
+        .end(),
     }))
     .create({});
 
@@ -23,13 +22,12 @@ it("can take an initial typed input", async () => {
   const store = types
     .model({})
     .actions((self) => ({
-      action1: flowPipe((input: string) => "hello " + input),
-      action2: flowPipe(
-        (input: number) => Promise.resolve(input),
-        (next) => next + 100,
-        (next) => Promise.resolve(next + 100),
-        (next) => Promise.resolve(next + "")
-      ),
+      action1: flowPipe((input: string) => "hello " + input).end(),
+      action2: flowPipe((input: number) => Promise.resolve(input))
+        .then((next) => next + 100)
+        .then((next) => Promise.resolve(next + 100))
+        .then((next) => Promise.resolve(next + ""))
+        .end(),
     }))
     .create({});
 
@@ -48,16 +46,15 @@ it("allows modification the model mid-flow", async () => {
       },
     }))
     .actions((self) => ({
-      action1: flowPipe(
-        (input: number) => {
-          self.value = input + "";
-          return input + 100;
-        },
-        (next) => {
+      action1: flowPipe((input: number) => {
+        self.value = input + "";
+        return input + 100;
+      })
+        .then((next) => {
           self.setValue(next + "");
           return Promise.resolve(next + 100);
-        }
-      ),
+        })
+        .end()
     }))
     .create({});
 
@@ -86,19 +83,17 @@ it("returns errors as promise rejections", async () => {
   const store = types
     .model({})
     .actions((self) => ({
-      action1: flowPipe(
-        (input: number) => Promise.resolve(input),
-        (num) => (num > 100 ? Promise.reject("naa") : num + 100),
-        (num) => Promise.resolve(num + "")
-      ),
-      action2: flowPipe(
-        (input: number) => Promise.resolve(input),
-        (num) => {
+      action1: flowPipe((input: number) => Promise.resolve(input))
+        .then((num) => (num > 100 ? Promise.reject("naa") : num + 100))
+        .then((num) => Promise.resolve(num + ""))
+        .end(),
+      action2: flowPipe((input: number) => Promise.resolve(input))
+        .then((num) => {
           if (num > 100) throw new Error("nope");
           return num + 100;
-        },
-        (num) => Promise.resolve(num + "")
-      ),
+        })
+        .then((num) => Promise.resolve(num + ""))
+        .end()
     }))
     .create({});
 
@@ -113,15 +108,12 @@ it("can optionally handle errors", async () => {
   const store = types
     .model({})
     .actions((self) => ({
-      action1: flowPipe(
-        [
-          (input: number) => Promise.resolve(input),
-          (num) => (num > 100 ? Promise.reject("naa") : num + 100),
-        ],
-        (err) => {
+      action1: flowPipe((input: number) => Promise.resolve(input))
+        .then((num) => (num > 100 ? Promise.reject("naa") : num + 100))
+        .catch((err) => {
           return "something bad happened";
-        }
-      ),
+        })
+        .end()
     }))
     .create({});
 
@@ -133,18 +125,15 @@ it("can optionally handle errors with no input", async () => {
   const store = types
     .model({})
     .actions((self) => ({
-      action1: flowPipe(
-        [
-          () => Promise.resolve({ a: "anon", b: 123 }),
-          (o) => {
-            if (o.b < 9999) throw new Error("oops");
-            return o.b;
-          },
-        ],
-        (err) => {
+      action1: flowPipe(() => Promise.resolve({ a: "anon", b: 123 }))
+        .then((o) => {
+          if (o.b < 9999) throw new Error("oops");
+          return o.b;
+        })
+        .catch((err) => {
           return "oopsie";
-        }
-      ),
+        })
+        .end()
     }))
     .create({});
 
@@ -155,17 +144,13 @@ it("can nest flow functions", async () => {
   const store = types
     .model({})
     .actions((self) => ({
-      action1: flowPipe((input: number) => Promise.resolve(input + 100)),
+      action1: flowPipe((input: number) => Promise.resolve(input + 100)).end(),
     }))
     .actions((self) => ({
-      action2: flowPipe([
-        (input: number) => Promise.resolve(input + 10),
-        (next) => self.action1(next + 10),
-
-        // Todo: work out why next here is typed at "unknown", if you forcefully type it to number
-        // its happy and string its not happy so thats good, but it should auto-type to number
-        (next) => next + "",
-      ]),
+      action2: flowPipe((input: number) => Promise.resolve(input + 10))
+        .then((next) => self.action1(next + 10))
+        .then((next) => next + "")
+        .end()
     }))
     .create({});
 


### PR DESCRIPTION
@mikecann Thanks for creating this library. It makes handling of async flows much more type-safe. 

I propose a change in API that I believe will address following limitations in the current API: 

1. Number of steps are limited to 5 (and overloads need to be added for every step).
2. Type-inference gets messed up in some [cases](https://github.com/mikecann/mst-flow-pipe/blob/master/test/index.test.ts#L167) (I think this is a TS bug). 
3. Error handling can not be interleaved and there can only be one terminal error handler step. 

The proposed API looks like this: 

```ts
flowPipe((input: number) => input + 1)
        .then((num) => (num > 100 ? Promise.reject("naa") : num + 100))
        .catch((err) => "something bad happened")
        .end()
```

The API is intentionally similar to the Promise API that I expect most users to be already familiar with.

Please let me know your thoughts.